### PR TITLE
feat: tickets module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ lerna-debug.log*
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@anatine/zod-nestjs": "^1.3.1",
+        "@casl/ability": "^5.4.3",
         "@nestjs/common": "^8.0.0",
         "@nestjs/config": "^1.2.0",
         "@nestjs/core": "^8.0.0",
@@ -828,6 +829,17 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@casl/ability": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-5.4.3.tgz",
+      "integrity": "sha512-X6U79udKkfS7459Y3DCkw58ZQno7BD9VJa5GnTL1rcKRACqERMVDs7qjVMW+JlLUZcT5DB2/GF5uvu0KsudEcA==",
+      "dependencies": {
+        "@ucast/mongo2js": "^1.3.0"
+      },
+      "funding": {
+        "url": "https://github.com/stalniy/casl/blob/master/BACKERS.md"
+      }
     },
     "node_modules/@cspotcode/source-map-consumer": {
       "version": "0.8.0",
@@ -2419,6 +2431,37 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ucast/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-sXKbvQiagjFh2JCpaHUa64P4UdJbOxYeC5xiZFn8y6iYdb0WkismduE+RmiJrIjw/eLDYmIEXiQeIYYowmkcAw=="
+    },
+    "node_modules/@ucast/js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.2.tgz",
+      "integrity": "sha512-zxNkdIPVvqJjHI7D/iK8Aai1+59yqU+N7bpHFodVmiTN7ukeNiGGpNmmSjQgsUw7eNcEBnPrZHNzp5UBxwmaPw==",
+      "dependencies": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "node_modules/@ucast/mongo": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.2.tgz",
+      "integrity": "sha512-/zH1TdBJlYGKKD+Wh0oyD+aBvDSWrwHcD8b4tUL9UgHLhzHtkEnMVFuxbw3SRIRsAa01wmy06+LWt+WoZdj1Bw==",
+      "dependencies": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "node_modules/@ucast/mongo2js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.3.3.tgz",
+      "integrity": "sha512-sBPtMUYg+hRnYeVYKL+ATm8FaRPdlU9PijMhGYKgsPGjV9J4Ks41ytIjGayvKUnBOEhiCaKUUnY4qPeifdqATw==",
+      "dependencies": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -10513,6 +10556,14 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@casl/ability": {
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/@casl/ability/-/ability-5.4.3.tgz",
+      "integrity": "sha512-X6U79udKkfS7459Y3DCkw58ZQno7BD9VJa5GnTL1rcKRACqERMVDs7qjVMW+JlLUZcT5DB2/GF5uvu0KsudEcA==",
+      "requires": {
+        "@ucast/mongo2js": "^1.3.0"
+      }
+    },
     "@cspotcode/source-map-consumer": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
@@ -11717,6 +11768,37 @@
       "requires": {
         "@typescript-eslint/types": "5.13.0",
         "eslint-visitor-keys": "^3.0.0"
+      }
+    },
+    "@ucast/core": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@ucast/core/-/core-1.10.1.tgz",
+      "integrity": "sha512-sXKbvQiagjFh2JCpaHUa64P4UdJbOxYeC5xiZFn8y6iYdb0WkismduE+RmiJrIjw/eLDYmIEXiQeIYYowmkcAw=="
+    },
+    "@ucast/js": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@ucast/js/-/js-3.0.2.tgz",
+      "integrity": "sha512-zxNkdIPVvqJjHI7D/iK8Aai1+59yqU+N7bpHFodVmiTN7ukeNiGGpNmmSjQgsUw7eNcEBnPrZHNzp5UBxwmaPw==",
+      "requires": {
+        "@ucast/core": "^1.0.0"
+      }
+    },
+    "@ucast/mongo": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo/-/mongo-2.4.2.tgz",
+      "integrity": "sha512-/zH1TdBJlYGKKD+Wh0oyD+aBvDSWrwHcD8b4tUL9UgHLhzHtkEnMVFuxbw3SRIRsAa01wmy06+LWt+WoZdj1Bw==",
+      "requires": {
+        "@ucast/core": "^1.4.1"
+      }
+    },
+    "@ucast/mongo2js": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ucast/mongo2js/-/mongo2js-1.3.3.tgz",
+      "integrity": "sha512-sBPtMUYg+hRnYeVYKL+ATm8FaRPdlU9PijMhGYKgsPGjV9J4Ks41ytIjGayvKUnBOEhiCaKUUnY4qPeifdqATw==",
+      "requires": {
+        "@ucast/core": "^1.6.1",
+        "@ucast/js": "^3.0.0",
+        "@ucast/mongo": "^2.4.0"
       }
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@anatine/zod-nestjs": "^1.3.1",
+    "@casl/ability": "^5.4.3",
     "@nestjs/common": "^8.0.0",
     "@nestjs/config": "^1.2.0",
     "@nestjs/core": "^8.0.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,7 @@ import { OrganizationsModule } from './organizations';
 import { UsersModule } from './users';
 import { CategoriesModule } from './categories';
 import { SequenceModule } from './sequence';
+import { TicketsModule } from './tickets';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { SequenceModule } from './sequence';
     UsersModule,
     CategoriesModule,
     SequenceModule,
+    TicketsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+import {
+  Ability,
+  AbilityBuilder,
+  ExtractSubjectType,
+  InferSubjects,
+} from '@casl/ability';
+import { Ticket } from '@/tickets';
+import { User } from '@/users';
+
+type Subjects = InferSubjects<typeof Ticket> | 'all';
+
+export type Action = 'manage' | 'create' | 'read' | 'update' | 'delete';
+
+export type AppAbility = Ability<[Action, Subjects]>;
+
+@Injectable()
+export class CaslAbilityFactory {
+  createForUser(user: User) {
+    const { can, build } = new AbilityBuilder<AppAbility>(Ability);
+
+    if (user.isAgent()) {
+      can('manage', 'all');
+    } else {
+      can('create', Ticket, ['categoryId', 'title', 'content']);
+      can('read', Ticket, { authorId: user.id });
+      can('update', Ticket, ['title', 'content'], { authorId: user.id });
+    }
+
+    return build({
+      detectSubjectType: (item) =>
+        item.constructor as ExtractSubjectType<Subjects>,
+    });
+  }
+}

--- a/src/casl/casl-ability.factory.ts
+++ b/src/casl/casl-ability.factory.ts
@@ -23,8 +23,8 @@ export class CaslAbilityFactory {
       can('manage', 'all');
     } else {
       can('create', Ticket, ['categoryId', 'title', 'content']);
-      can('read', Ticket, { authorId: user.id });
-      can('update', Ticket, ['title', 'content'], { authorId: user.id });
+      can('read', Ticket, { requesterId: user.id });
+      can('update', Ticket, ['title', 'content'], { requesterId: user.id });
     }
 
     return build({

--- a/src/casl/casl.module.ts
+++ b/src/casl/casl.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { CaslAbilityFactory } from './casl-ability.factory';
+
+@Module({
+  providers: [CaslAbilityFactory],
+  exports: [CaslAbilityFactory],
+})
+export class CaslModule {}

--- a/src/casl/index.ts
+++ b/src/casl/index.ts
@@ -1,0 +1,2 @@
+export { CaslAbilityFactory } from './casl-ability.factory';
+export { CaslModule } from './casl.module';

--- a/src/categories/categories.module.ts
+++ b/src/categories/categories.module.ts
@@ -8,5 +8,6 @@ import { Category } from './entities/category.entity';
   imports: [TypeOrmModule.forFeature([Category])],
   providers: [CategoriesService],
   controllers: [CategoriesController],
+  exports: [CategoriesService],
 })
 export class CategoriesModule {}

--- a/src/categories/index.ts
+++ b/src/categories/index.ts
@@ -1,1 +1,2 @@
 export { CategoriesModule } from './categories.module';
+export { CategoriesService } from './categories.service';

--- a/src/common/schemas/pagination.schema.ts
+++ b/src/common/schemas/pagination.schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+function castInt(value: any) {
+  if (typeof value === 'string') {
+    return parseInt(value);
+  }
+  return value;
+}
+
+export const PaginationSchema = z.object({
+  page: z.preprocess(castInt, z.number().positive().optional()),
+  pageSize: z.preprocess(castInt, z.number().positive().max(100).optional()),
+});

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -7,6 +7,7 @@ import { default as config } from './ormconfig';
     TypeOrmModule.forRoot({
       ...config,
       autoLoadEntities: true,
+      logging: process.env.NODE_ENV !== 'production',
     }),
   ],
   exports: [TypeOrmModule],

--- a/src/database/migrations/1647940961244-create-tickets-table.ts
+++ b/src/database/migrations/1647940961244-create-tickets-table.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createTicketsTable1647940961244 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE tickets (
+        id              int(11) unsigned     NOT NULL AUTO_INCREMENT,
+        organization_id int(11) unsigned     NOT NULL,
+        nid             int(11) unsigned     NOT NULL,
+        category_id     int(11) unsigned     NOT NULL,
+        author_id       int(11) unsigned     NOT NULL,
+        assignee_id     int(11) unsigned,
+        title           varchar(255)         NOT NULL,
+        content         text                 NOT NULL,
+        reply_count     smallint(6) unsigned NOT NULL DEFAULT 0,
+        status          smallint(6) unsigned NOT NULL,
+        created_at      datetime(3)          NOT NULL DEFAULT NOW(3),
+        updated_at      datetime(3)          NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
+        PRIMARY KEY (id),
+        INDEX ix_tickets_organization_id_id (organization_id,id),
+        UNIQUE KEY uq_tickets_organization_id_nid (organization_id,nid)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE tickets;');
+  }
+}

--- a/src/database/migrations/1647940961244-create-tickets-table.ts
+++ b/src/database/migrations/1647940961244-create-tickets-table.ts
@@ -20,7 +20,6 @@ export class createTicketsTable1647940961244 implements MigrationInterface {
         UNIQUE KEY uq_tickets_organization_id_nid (organization_id,nid),
         INDEX ix_tickets_organization_id_id (organization_id,id),
         INDEX ix_tickets_organization_id_status (organization_id,status),
-        INDEX ix_tickets_organization_id_created_at (organization_id,created_at),
         INDEX ix_tickets_organization_id_updated_at (organization_id,updated_at)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
     `);

--- a/src/database/migrations/1647940961244-create-tickets-table.ts
+++ b/src/database/migrations/1647940961244-create-tickets-table.ts
@@ -17,8 +17,11 @@ export class createTicketsTable1647940961244 implements MigrationInterface {
         created_at      datetime(3)          NOT NULL DEFAULT NOW(3),
         updated_at      datetime(3)          NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
         PRIMARY KEY (id),
+        UNIQUE KEY uq_tickets_organization_id_nid (organization_id,nid),
         INDEX ix_tickets_organization_id_id (organization_id,id),
-        UNIQUE KEY uq_tickets_organization_id_nid (organization_id,nid)
+        INDEX ix_tickets_organization_id_status (organization_id,status),
+        INDEX ix_tickets_organization_id_created_at (organization_id,created_at),
+        INDEX ix_tickets_organization_id_updated_at (organization_id,updated_at)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
     `);
   }

--- a/src/database/migrations/1647940961244-create-tickets-table.ts
+++ b/src/database/migrations/1647940961244-create-tickets-table.ts
@@ -4,23 +4,25 @@ export class createTicketsTable1647940961244 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       CREATE TABLE tickets (
-        id              int(11) unsigned     NOT NULL AUTO_INCREMENT,
-        organization_id int(11) unsigned     NOT NULL,
-        nid             int(11) unsigned     NOT NULL,
-        category_id     int(11) unsigned     NOT NULL,
-        author_id       int(11) unsigned     NOT NULL,
-        assignee_id     int(11) unsigned,
-        title           varchar(255)         NOT NULL,
-        content         text                 NOT NULL,
-        reply_count     smallint(6) unsigned NOT NULL DEFAULT 0,
-        status          smallint(6) unsigned NOT NULL,
-        created_at      datetime(3)          NOT NULL DEFAULT NOW(3),
-        updated_at      datetime(3)          NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
+        id           int(11) unsigned     NOT NULL AUTO_INCREMENT,
+        org_id       int(11) unsigned     NOT NULL,
+        seq          int(11) unsigned     NOT NULL,
+        category_id  int(11) unsigned     NOT NULL,
+        requester_id int(11) unsigned     NOT NULL,
+        assignee_id  int(11) unsigned,
+        title        varchar(255)         NOT NULL,
+        content      text                 NOT NULL,
+        reply_count  smallint(6) unsigned NOT NULL DEFAULT 0,
+        status       smallint(6) unsigned NOT NULL,
+        created_at   datetime(3)          NOT NULL DEFAULT NOW(3),
+        updated_at   datetime(3)          NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
         PRIMARY KEY (id),
-        UNIQUE KEY uq_tickets_organization_id_nid (organization_id,nid),
-        INDEX ix_tickets_organization_id_id (organization_id,id),
-        INDEX ix_tickets_organization_id_status (organization_id,status),
-        INDEX ix_tickets_organization_id_updated_at (organization_id,updated_at)
+        UNIQUE KEY uq_tickets_org_id_seq (org_id,seq),
+        INDEX ix_tickets_org_id_id (org_id,id),
+        INDEX ix_tickets_org_id_requester_id (org_id,requester_id),
+        INDEX ix_tickets_org_id_assignee_id (org_id,assignee_id),
+        INDEX ix_tickets_org_id_status (org_id,status),
+        INDEX ix_tickets_org_id_updated_at (org_id,updated_at)
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
     `);
   }

--- a/src/sequence/sequence.module.ts
+++ b/src/sequence/sequence.module.ts
@@ -1,4 +1,4 @@
-import { FactoryProvider, Global, Module } from '@nestjs/common';
+import { FactoryProvider, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import Redis from 'ioredis';
 import { SEQUENCE_REDIS } from './constants';
@@ -12,7 +12,6 @@ const redisFactory: FactoryProvider = {
   },
 };
 
-@Global()
 @Module({
   providers: [redisFactory, SequenceService],
   exports: [SequenceService],

--- a/src/sequence/sequence.service.ts
+++ b/src/sequence/sequence.service.ts
@@ -7,7 +7,7 @@ export class SequenceService {
   @Inject(SEQUENCE_REDIS)
   private redis: Redis;
 
-  getNextId(organizationId: number, name: string): Promise<number> {
+  getNext(organizationId: number, name: string): Promise<number> {
     const sequenceKey = `org:${organizationId}:seq:${name}`;
     return this.redis.incr(sequenceKey);
   }

--- a/src/tickets/constants.ts
+++ b/src/tickets/constants.ts
@@ -1,0 +1,7 @@
+export const status = {
+  new: 50,
+  waitingAgent: 120,
+  waitingCustomer: 160,
+  preFulfilled: 220,
+  closed: 280,
+};

--- a/src/tickets/dtos/create-ticket.dto.ts
+++ b/src/tickets/dtos/create-ticket.dto.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+import { createZodDto } from '@anatine/zod-nestjs';
+
+export const CreateTicketSchema = z.object({
+  authorId: z.number().optional(),
+  categoryId: z.number(),
+  title: z.string(),
+  content: z.string(),
+});
+
+export class CreateTicketDto extends createZodDto(CreateTicketSchema) {}

--- a/src/tickets/dtos/create-ticket.dto.ts
+++ b/src/tickets/dtos/create-ticket.dto.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { createZodDto } from '@anatine/zod-nestjs';
 
 export const CreateTicketSchema = z.object({
-  authorId: z.number().optional(),
+  requesterId: z.number().optional(),
   categoryId: z.number(),
   title: z.string(),
   content: z.string(),

--- a/src/tickets/dtos/find-tickets.dto.ts
+++ b/src/tickets/dtos/find-tickets.dto.ts
@@ -13,7 +13,7 @@ export const FindTicketsSchema = PaginationSchema.extend({
         field = field.slice(1);
       }
       if (field === 'id') {
-        field = 'nid';
+        field = 'seq';
       }
       return [field, desc ? 'DESC' : 'ASC'];
     })

--- a/src/tickets/dtos/find-tickets.dto.ts
+++ b/src/tickets/dtos/find-tickets.dto.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+import { createZodDto } from '@anatine/zod-nestjs';
+import { PaginationSchema } from '@/common/schemas/pagination.schema';
+
+const ORDER_FIELDS = ['id', 'updatedAt', 'status'] as const;
+
+export const FindTicketsSchema = PaginationSchema.extend({
+  orderBy: z
+    .enum([...ORDER_FIELDS, ...ORDER_FIELDS.map((field) => '-' + field)])
+    .transform<[string, 'ASC' | 'DESC']>((field) => {
+      const desc = field.startsWith('-');
+      if (desc) {
+        field = field.slice(1);
+      }
+      if (field === 'id') {
+        field = 'nid';
+      }
+      return [field, desc ? 'DESC' : 'ASC'];
+    })
+    .optional(),
+});
+
+export class FindTicketsDto extends createZodDto(FindTicketsSchema) {}

--- a/src/tickets/dtos/update-ticket.dto.ts
+++ b/src/tickets/dtos/update-ticket.dto.ts
@@ -3,7 +3,7 @@ import { createZodDto } from '@anatine/zod-nestjs';
 import { CreateTicketSchema } from './create-ticket.dto';
 
 export const UpdateTicketSchema = CreateTicketSchema.omit({
-  authorId: true,
+  requesterId: true,
 })
   .partial()
   .extend({

--- a/src/tickets/dtos/update-ticket.dto.ts
+++ b/src/tickets/dtos/update-ticket.dto.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+import { createZodDto } from '@anatine/zod-nestjs';
+import { CreateTicketSchema } from './create-ticket.dto';
+
+export const UpdateTicketSchema = CreateTicketSchema.omit({
+  authorId: true,
+})
+  .partial()
+  .extend({
+    assigneeId: z.number().optional(),
+  });
+
+export class UpdateTicketDto extends createZodDto(UpdateTicketSchema) {}

--- a/src/tickets/entities/ticket.entity.ts
+++ b/src/tickets/entities/ticket.entity.ts
@@ -1,0 +1,52 @@
+import { Exclude, Expose } from 'class-transformer';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('tickets')
+@Exclude()
+export class Ticket {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column({ name: 'organization_id' })
+  organizationId: number;
+
+  @Column()
+  @Expose({ name: 'id' })
+  nid: number;
+
+  @Column({ name: 'category_id' })
+  @Expose()
+  categoryId: number;
+
+  @Column({ name: 'author_id' })
+  @Expose()
+  authorId: number;
+
+  @Column({ name: 'assignee_id' })
+  @Expose()
+  assigneeId?: number;
+
+  @Column()
+  @Expose()
+  title: string;
+
+  @Column()
+  @Expose()
+  content: string;
+
+  @Column({ name: 'reply_count' })
+  @Expose()
+  replyCount: number;
+
+  @Column()
+  @Expose()
+  status: number;
+
+  @Column({ name: 'created_at' })
+  @Expose()
+  createdAt: Date;
+
+  @Column({ name: 'updated_at' })
+  @Expose()
+  updatedAt: Date;
+}

--- a/src/tickets/entities/ticket.entity.ts
+++ b/src/tickets/entities/ticket.entity.ts
@@ -7,20 +7,20 @@ export class Ticket {
   @PrimaryGeneratedColumn()
   id: number;
 
-  @Column({ name: 'organization_id' })
-  organizationId: number;
+  @Column({ name: 'org_id' })
+  orgId: number;
 
   @Column()
   @Expose({ name: 'id' })
-  nid: number;
+  seq: number;
 
   @Column({ name: 'category_id' })
   @Expose()
   categoryId: number;
 
-  @Column({ name: 'author_id' })
+  @Column({ name: 'requester_id' })
   @Expose()
-  authorId: number;
+  requesterId: number;
 
   @Column({ name: 'assignee_id' })
   @Expose()

--- a/src/tickets/index.ts
+++ b/src/tickets/index.ts
@@ -1,2 +1,3 @@
 export { Ticket } from './entities/ticket.entity';
+export { TicketsService } from './ticket.service';
 export { TicketsModule } from './tickets.module';

--- a/src/tickets/index.ts
+++ b/src/tickets/index.ts
@@ -1,1 +1,2 @@
+export { Ticket } from './entities/ticket.entity';
 export { TicketsModule } from './tickets.module';

--- a/src/tickets/index.ts
+++ b/src/tickets/index.ts
@@ -1,0 +1,1 @@
+export { TicketsModule } from './tickets.module';

--- a/src/tickets/ticket.service.ts
+++ b/src/tickets/ticket.service.ts
@@ -121,7 +121,7 @@ export class TicketsService {
   }
 
   private getNextSeq(orgId: number) {
-    return this.sequenceService.getNext(orgId, 'ticketNid');
+    return this.sequenceService.getNext(orgId, 'ticket');
   }
 
   private async assertAssigneeIdIsValid(orgId: number, assigneeId: number) {

--- a/src/tickets/ticket.service.ts
+++ b/src/tickets/ticket.service.ts
@@ -1,0 +1,80 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import _ from 'lodash';
+import { CategoriesService } from '@/categories';
+import { SequenceService } from '@/sequence';
+import { UsersService } from '@/users';
+import { CreateTicketDto } from './dtos/create-ticket.dto';
+import { Ticket } from './entities/ticket.entity';
+import { status } from './constants';
+import { UpdateTicketDto } from './dtos/update-ticket.dto';
+
+@Injectable()
+export class TicketsService {
+  @InjectRepository(Ticket)
+  private ticketsRepository: Repository<Ticket>;
+
+  constructor(
+    private sequenceService: SequenceService,
+    private categoriesService: CategoriesService,
+    private usersService: UsersService,
+  ) {}
+
+  findOne(organizationId: number, id: number): Promise<Ticket | undefined> {
+    return this.ticketsRepository.findOne({ organizationId, id });
+  }
+
+  findOneByNid(
+    organizationId: number,
+    nid: number,
+  ): Promise<Ticket | undefined> {
+    return this.ticketsRepository.findOne({ organizationId, nid });
+  }
+
+  async findOneByNidOrFail(
+    organizationId: number,
+    nid: number,
+  ): Promise<Ticket> {
+    const ticket = await this.findOneByNid(organizationId, nid);
+    if (!ticket) {
+      throw new NotFoundException(`ticket ${nid} does not exist`);
+    }
+    return ticket;
+  }
+
+  async create(organizationId: number, data: CreateTicketDto): Promise<number> {
+    await this.categoriesService.findOneOrFail(organizationId, data.categoryId);
+    const ticket = new Ticket();
+    ticket.organizationId = organizationId;
+    ticket.nid = await this.getNextNid(organizationId);
+    ticket.status = status.new;
+    ticket.authorId = data.authorId;
+    ticket.categoryId = data.categoryId;
+    ticket.title = data.title;
+    ticket.content = data.content;
+    ticket.replyCount = 0;
+    await this.ticketsRepository.insert(ticket);
+    return ticket.id;
+  }
+
+  async update(organizationId: number, nid: number, data: UpdateTicketDto) {
+    if (_.isEmpty(data)) {
+      return;
+    }
+    if (data.categoryId) {
+      await this.categoriesService.findOneOrFail(
+        organizationId,
+        data.categoryId,
+      );
+    }
+    if (data.assigneeId) {
+      await this.usersService.findOneOrFail(organizationId, data.assigneeId);
+    }
+    await this.ticketsRepository.update({ organizationId, nid }, data);
+  }
+
+  private getNextNid(organizationId: number) {
+    return this.sequenceService.getNextId(organizationId, 'ticketNid');
+  }
+}

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -46,7 +46,7 @@ export class TicketsController {
         );
       }
     });
-    data.authorId ??= user.id;
+    data.requesterId ??= user.id;
     const id = await this.ticketsService.create(org.id, data);
     const ticket = await this.ticketsService.findOne(org.id, id);
     return {
@@ -69,13 +69,13 @@ export class TicketsController {
     };
   }
 
-  @Get(':nid')
+  @Get(':seq')
   async findOne(
     @Org() org: Organization,
     @CurrentUser() user: User,
-    @Param('nid', ParseIntPipe) nid: number,
+    @Param('seq', ParseIntPipe) seq: number,
   ) {
-    const ticket = await this.ticketsService.findOneByNidOrFail(org.id, nid);
+    const ticket = await this.ticketsService.findOneBySeqOrFail(org.id, seq);
     const ability = this.caslAbilityFactory.createForUser(user);
     if (ability.cannot('read', ticket)) {
       throw new ForbiddenException();
@@ -85,14 +85,14 @@ export class TicketsController {
     };
   }
 
-  @Patch(':nid')
+  @Patch(':seq')
   async update(
     @Org() org: Organization,
     @CurrentUser() user: User,
-    @Param('nid', ParseIntPipe) nid: number,
+    @Param('seq', ParseIntPipe) seq: number,
     @Body() data: UpdateTicketDto,
   ) {
-    let ticket = await this.ticketsService.findOneByNidOrFail(org.id, nid);
+    let ticket = await this.ticketsService.findOneBySeqOrFail(org.id, seq);
     const ability = this.caslAbilityFactory.createForUser(user);
     if (ability.cannot('update', ticket)) {
       throw new ForbiddenException();
@@ -105,7 +105,7 @@ export class TicketsController {
       }
     });
     if (!_.isEmpty(data)) {
-      await this.ticketsService.update(org.id, nid, data);
+      await this.ticketsService.update(org.id, seq, data);
       ticket = await this.ticketsService.findOne(org.id, ticket.id);
     }
     return {

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -1,0 +1,83 @@
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  UseGuards,
+  UsePipes,
+} from '@nestjs/common';
+import { ZodValidationPipe } from '@anatine/zod-nestjs';
+import _ from 'lodash';
+import { AuthGuard, CurrentUser, Org } from '@/common';
+import { Organization } from '@/organizations';
+import { User } from '@/users';
+import { CreateTicketDto } from './dtos/create-ticket.dto';
+import { TicketsService } from './ticket.service';
+import { UpdateTicketDto } from './dtos/update-ticket.dto';
+
+@Controller('tickets')
+@UseGuards(AuthGuard)
+@UsePipes(ZodValidationPipe)
+export class TicketsController {
+  constructor(private ticketsService: TicketsService) {}
+
+  @Post()
+  async create(
+    @Org() org: Organization,
+    @CurrentUser() user: User,
+    @Body() data: CreateTicketDto,
+  ) {
+    if (data.authorId === undefined || !user.isAgent()) {
+      data.authorId = user.id;
+    }
+    const id = await this.ticketsService.create(org.id, data);
+    const ticket = await this.ticketsService.findOne(org.id, id);
+    return {
+      ticket,
+    };
+  }
+
+  @Get(':nid')
+  async findOne(
+    @Org() org: Organization,
+    @CurrentUser() user: User,
+    @Param('nid', ParseIntPipe) nid: number,
+  ) {
+    const ticket = await this.ticketsService.findOneByNidOrFail(org.id, nid);
+    if (!user.isAgent() && user.id !== ticket.authorId) {
+      throw new ForbiddenException();
+    }
+    return {
+      ticket,
+    };
+  }
+
+  @Patch(':nid')
+  async update(
+    @Org() org: Organization,
+    @CurrentUser() user: User,
+    @Param('nid', ParseIntPipe) nid: number,
+    @Body() data: UpdateTicketDto,
+  ) {
+    let ticket = await this.ticketsService.findOneByNidOrFail(org.id, nid);
+    if (!user.isAgent()) {
+      if (user.id !== ticket.authorId) {
+        throw new ForbiddenException();
+      }
+      if (data.assigneeId) {
+        throw new ForbiddenException();
+      }
+    }
+    if (!_.isEmpty(data)) {
+      await this.ticketsService.update(org.id, nid, data);
+      ticket = await this.ticketsService.findOne(org.id, ticket.id);
+    }
+    return {
+      ticket,
+    };
+  }
+}

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -7,6 +7,7 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UsePipes,
 } from '@nestjs/common';
@@ -20,6 +21,7 @@ import { CreateTicketDto } from './dtos/create-ticket.dto';
 import { UpdateTicketDto } from './dtos/update-ticket.dto';
 import { Ticket } from './entities/ticket.entity';
 import { TicketsService } from './ticket.service';
+import { FindTicketsDto } from './dtos/find-tickets.dto';
 
 @Controller('tickets')
 @UseGuards(AuthGuard)
@@ -49,6 +51,21 @@ export class TicketsController {
     const ticket = await this.ticketsService.findOne(org.id, id);
     return {
       ticket,
+    };
+  }
+
+  @Get()
+  async find(
+    @Org() org: Organization,
+    @CurrentUser() user: User,
+    @Query() params: FindTicketsDto,
+  ) {
+    if (!user.isAgent()) {
+      throw new ForbiddenException();
+    }
+    const tickets = await this.ticketsService.find(org.id, params as any);
+    return {
+      tickets,
     };
   }
 

--- a/src/tickets/tickets.module.ts
+++ b/src/tickets/tickets.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CaslModule } from '@/casl';
 import { CategoriesModule } from '@/categories';
@@ -14,9 +14,10 @@ import { TicketsController } from './tickets.controller';
     CaslModule,
     CategoriesModule,
     SequenceModule,
-    UsersModule,
+    forwardRef(() => UsersModule),
   ],
   providers: [TicketsService],
   controllers: [TicketsController],
+  exports: [TicketsService],
 })
 export class TicketsModule {}

--- a/src/tickets/tickets.module.ts
+++ b/src/tickets/tickets.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { CaslModule } from '@/casl';
 import { CategoriesModule } from '@/categories';
 import { SequenceModule } from '@/sequence';
 import { UsersModule } from '@/users';
@@ -10,6 +11,7 @@ import { TicketsController } from './tickets.controller';
 @Module({
   imports: [
     TypeOrmModule.forFeature([Ticket]),
+    CaslModule,
     CategoriesModule,
     SequenceModule,
     UsersModule,

--- a/src/tickets/tickets.module.ts
+++ b/src/tickets/tickets.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CategoriesModule } from '@/categories';
+import { SequenceModule } from '@/sequence';
+import { UsersModule } from '@/users';
+import { Ticket } from './entities/ticket.entity';
+import { TicketsService } from './ticket.service';
+import { TicketsController } from './tickets.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Ticket]),
+    CategoriesModule,
+    SequenceModule,
+    UsersModule,
+  ],
+  providers: [TicketsService],
+  controllers: [TicketsController],
+})
+export class TicketsModule {}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -1,11 +1,12 @@
-import { Module } from '@nestjs/common';
+import { TicketsModule } from '@/tickets';
+import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User]), forwardRef(() => TicketsModule)],
   providers: [UsersService],
   controllers: [UsersController],
   exports: [UsersService],


### PR DESCRIPTION
简易的「工单」模块，包含创建、更新和获取工单列表的功能。回复功能也打算放到工单模块内部，但这个 PR 的内容已经有点多了，就不在这个 PR 里实现了。

获取工单列表只包含简单的分页和排序功能，筛选依靠不同的接口实现：
- `GET /users/:id/tickets/requested` 获取某个用户提交的工单
- `GET /users/:id/tickets/assigned`  获取分配给某个用户的工单
- `GET /tickets` 获取全部工单

复杂的筛选和排序打算使用 es 实现，并单独提供一个接口（Zendesk [也是这么做的](https://developer.zendesk.com/api-reference/ticketing/tickets/tickets/#list-tickets)）。就不一个功能实现 2 次了，而且 MySQL 也不适合做搜索。