### PR TITLE
feat: remove reply_count column

### DIFF
--- a/src/database/migrations/1647940961244-create-ticket-table.ts
+++ b/src/database/migrations/1647940961244-create-ticket-table.ts
@@ -13,7 +13,6 @@ export class createTicketTable1647940961244 implements MigrationInterface {
         title        varchar(255)         NOT NULL,
         content      text                 NOT NULL,
         html_content text                 NOT NULL,
-        reply_count  smallint(6) unsigned NOT NULL DEFAULT 0,
         status       smallint(6) unsigned NOT NULL,
         created_at   datetime(3)          NOT NULL DEFAULT NOW(3),
         updated_at   datetime(3)          NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),

--- a/src/ticket/entities/ticket.entity.ts
+++ b/src/ticket/entities/ticket.entity.ts
@@ -38,10 +38,6 @@ export class Ticket {
   @Expose()
   htmlContent: string;
 
-  @Column({ name: 'reply_count' })
-  @Expose()
-  replyCount: number;
-
   @Column()
   @Expose()
   status: number;

--- a/src/ticket/reply.service.ts
+++ b/src/ticket/reply.service.ts
@@ -1,16 +1,12 @@
 import { Injectable } from '@nestjs/common';
-import { InjectConnection, InjectRepository } from '@nestjs/typeorm';
-import { Connection, Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import { MarkdownService } from '@/markdown';
 import { Reply } from './entities/reply.entity';
-import { Ticket } from './entities/ticket.entity';
 import { CreateReplyDto } from './dtos/create-reply.dto';
 
 @Injectable()
 export class ReplyService {
-  @InjectConnection()
-  private connection: Connection;
-
   @InjectRepository(Reply)
   private replyRepository: Repository<Reply>;
 
@@ -30,16 +26,7 @@ export class ReplyService {
     reply.content = data.content;
     reply.htmlContent = this.markdownService.render(data.content);
 
-    await this.connection.transaction(async (manager) => {
-      await manager.insert(Reply, reply);
-      await manager.update(
-        Ticket,
-        { orgId, id: ticketId },
-        {
-          replyCount: () => 'reply_count + 1',
-        },
-      );
-    });
+    await this.replyRepository.insert(reply);
 
     return reply.id;
   }


### PR DESCRIPTION
确认 dc 和 tgb 没有使用 replyCount 字段，就先去掉了，不行后续再加上。第一版力求简洁。

还给更新索引的 job 加了个重试的逻辑。多实例怎么都不好解决任务执行顺序的问题，希望通过重试解决更新任务先于创建任务执行（找不到文档）的问题。