### PR TITLE
feat: number role

### DIFF
--- a/src/database/migrations/1646795337469-create-user-table.ts
+++ b/src/database/migrations/1646795337469-create-user-table.ts
@@ -4,17 +4,17 @@ export class createUserTable1646795337469 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       CREATE TABLE user (
-        id         int(11) unsigned NOT NULL AUTO_INCREMENT,
-        org_id     int(11) unsigned NOT NULL,
-        username   varchar(255)     NOT NULL,
-        password   varchar(255)     NOT NULL,
+        id         int(11) unsigned    NOT NULL AUTO_INCREMENT,
+        org_id     int(11) unsigned    NOT NULL,
+        username   varchar(255)        NOT NULL,
+        password   varchar(255)        NOT NULL,
         email      varchar(255),
-        role       varchar(255)     NOT NULL,
-        created_at datetime(3)      NOT NULL DEFAULT NOW(3),
-        updated_at datetime(3)      NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
+        role       tinyint(4) unsigned NOT NULL,
+        created_at datetime(3)         NOT NULL DEFAULT NOW(3),
+        updated_at datetime(3)         NOT NULL DEFAULT NOW(3) ON UPDATE NOW(3),
         PRIMARY KEY (id),
         INDEX ix_user_org_id_id (org_id,id),
-        INDEX ix_user_org_id_role (org_id,role(10)),
+        INDEX ix_user_org_id_role (org_id,role),
         UNIQUE KEY uq_user_org_id_username (org_id,username(20)),
         UNIQUE KEY uq_user_org_id_email (org_id,email(20))
       ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;

--- a/src/user/constants.ts
+++ b/src/user/constants.ts
@@ -1,1 +1,0 @@
-export const USER_ROLES = ['end-user', 'agent', 'admin'] as const;

--- a/src/user/dtos/find-users-params.dto.ts
+++ b/src/user/dtos/find-users-params.dto.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { createZodDto } from '@anatine/zod-nestjs';
-import { USER_ROLES } from '../constants';
+import { UserRole } from '../types';
 
 function castInt(value: unknown) {
   if (typeof value === 'string') {
@@ -8,13 +8,20 @@ function castInt(value: unknown) {
   }
 }
 
+const roleNames = {
+  'end-user': UserRole.EndUser,
+  agent: UserRole.Agent,
+  admin: UserRole.Admin,
+};
+
+export const UserRoleSchema = z
+  .enum(Object.keys(roleNames) as [string, ...string[]])
+  .transform<number>((name) => roleNames[name]);
+
 export const FindUsersSchema = z.object({
   page: z.preprocess(castInt, z.number().positive().default(1)),
   pageSize: z.preprocess(castInt, z.number().positive().max(100).default(100)),
-  role: z
-    .enum(USER_ROLES)
-    .or(z.array(z.enum(USER_ROLES)))
-    .optional(),
+  role: z.union([UserRoleSchema, z.array(UserRoleSchema)]).optional(),
 });
 
 export class FindUsersParams extends createZodDto(FindUsersSchema) {}

--- a/src/user/dtos/update-user.dto.ts
+++ b/src/user/dtos/update-user.dto.ts
@@ -1,12 +1,11 @@
-import { z } from 'zod';
 import { createZodDto } from '@anatine/zod-nestjs';
-import { USER_ROLES } from '../constants';
 import { CreateUserSchema } from './create-user.dto';
+import { UserRoleSchema } from './find-users-params.dto';
 
 export const UpdateUserSchema = CreateUserSchema.pick({
   email: true,
 }).extend({
-  role: z.enum(USER_ROLES).optional(),
+  role: UserRoleSchema.optional(),
 });
 
 export class UpdateUserDto extends createZodDto(UpdateUserSchema) {}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -25,7 +25,6 @@ export class User {
   email: string;
 
   @Column()
-  @Expose()
   role: UserRole;
 
   @Column({ name: 'created_at' })
@@ -48,10 +47,24 @@ export class User {
   }
 
   isAdmin() {
-    return this.role === 'admin';
+    return this.role === UserRole.Admin;
   }
 
   isAgent() {
-    return this.isAdmin() || this.role === 'agent';
+    return this.isAdmin() || this.role === UserRole.Agent;
+  }
+
+  @Expose({ name: 'role' })
+  getRoleName() {
+    switch (this.role) {
+      case UserRole.EndUser:
+        return 'end-user';
+      case UserRole.LiteAgent:
+        return 'lite-agent';
+      case UserRole.Agent:
+        return 'agent';
+      case UserRole.Admin:
+        return 'admin';
+    }
   }
 }

--- a/src/user/types.ts
+++ b/src/user/types.ts
@@ -1,3 +1,6 @@
-import { USER_ROLES } from './constants';
-
-export type UserRole = typeof USER_ROLES[number];
+export enum UserRole {
+  EndUser = 1,
+  LiteAgent = 2,
+  Agent = 3,
+  Admin = 4,
+}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -10,6 +10,7 @@ import { User } from './entities/user.entity';
 import { CreateUserDto } from './dtos/create-user.dto';
 import { UpdateUserDto } from './dtos/update-user.dto';
 import { FindUsersParams } from './dtos/find-users-params.dto';
+import { UserRole } from './types';
 
 @Injectable()
 export class UserService {
@@ -98,7 +99,7 @@ export class UserService {
     user.username = data.username;
     await user.setPassword(data.password);
     user.email = data.email;
-    user.role = 'end-user';
+    user.role = UserRole.EndUser;
     await this.userRepository.insert(user);
     return user.id;
   }


### PR DESCRIPTION
之前用字符串保存「角色」的设计有点蠢，改成用 tinyint 保存了。仿照 zendesk 预设 4 个角色（`end-user`, `lite-agent`, `agent`, `admin`），估摸着也是够用了。不够就直接向上递增添加，不追求通过数字大小表示权限大小了。