### PR TITLE
feat: strict subdomain

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,8 +4,7 @@ import { join } from 'path';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { BullModule } from '@nestjs/bull';
 import { OrganizationMiddleware } from './common';
-import { cacheConfig, queueConfig, sequenceConfig } from './config/redis';
-import { elasticsearchConfig } from './config/elasticsearch';
+import { configs } from './config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth';
@@ -25,7 +24,7 @@ import { TicketModule } from './ticket';
     }),
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [cacheConfig, queueConfig, sequenceConfig, elasticsearchConfig],
+      load: configs,
     }),
     BullModule.forRootAsync({
       inject: [ConfigService],

--- a/src/common/guards/master-key.guard.ts
+++ b/src/common/guards/master-key.guard.ts
@@ -1,12 +1,13 @@
 import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { Request } from 'express';
 
 @Injectable()
 export class MasterKeyGuard implements CanActivate {
-  private masterKey: string;
+  private masterKey: string | undefined;
 
-  constructor() {
-    this.masterKey = process.env.LEANCLOUD_APP_MASTER_KEY;
+  constructor(configService: ConfigService) {
+    this.masterKey = configService.get('masterKey');
   }
 
   canActivate(ctx: ExecutionContext): boolean {

--- a/src/common/middlewares/organization.middleware.ts
+++ b/src/common/middlewares/organization.middleware.ts
@@ -51,10 +51,10 @@ export class OrganizationMiddleware implements NestMiddleware {
   }
 
   private getSubdomainFromHostname(baseUrl: string, hostname: string) {
-    const length = hostname.length - baseUrl.length;
-    if (length > 1 && hostname.endsWith(baseUrl)) {
-      // use length - 1 to remove dot
-      return hostname.slice(0, length - 1);
+    const suffix = '.' + baseUrl;
+    const length = hostname.length - suffix.length;
+    if (length > 0 && hostname.endsWith(suffix)) {
+      return hostname.slice(0, length);
     }
   }
 }

--- a/src/config/common.ts
+++ b/src/config/common.ts
@@ -1,0 +1,4 @@
+export default () => ({
+  baseUrl: process.env.BASE_URL,
+  masterKey: process.env.LEANCLOUD_APP_MASTER_KEY,
+});

--- a/src/config/elasticsearch.ts
+++ b/src/config/elasticsearch.ts
@@ -1,5 +1,5 @@
 import { registerAs } from '@nestjs/config';
 
-export const elasticsearchConfig = registerAs('elasticsearch', () => ({
+export default registerAs('elasticsearch', () => ({
   url: process.env.ELASTICSEARCH_URL_MYES,
 }));

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,11 @@
+import common from './common';
+import elasticsearch from './elasticsearch';
+import { cacheConfig, queueConfig, sequenceConfig } from './redis';
+
+export const configs = [
+  common,
+  elasticsearch,
+  cacheConfig,
+  queueConfig,
+  sequenceConfig,
+];


### PR DESCRIPTION
通过配置 baseUrl 来避免仅使用 express 的 subdomains 数组获取 subdomain 时无法区分 `foo.example.com` 与 `foo.bar.example.com` 的问题。

未配置 baseUrl 时继续使用之前的逻辑 👀 