### PR TITLE
feat: auto select ticket assignee

### DIFF
--- a/src/category/category.module.ts
+++ b/src/category/category.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { User } from '@/user/entities/user.entity';
 import { CategoryController } from './category.controller';
 import { CategoryService } from './category.service';
 import { Category } from './entities/category.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Category])],
+  imports: [TypeOrmModule.forFeature([Category, User])],
   providers: [CategoryService],
   controllers: [CategoryController],
   exports: [CategoryService],

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -57,6 +57,14 @@ export class CategoryService {
     return category.users;
   }
 
+  async getUserIds(categoryId: number): Promise<number[]> {
+    const rows = await this.connection.query(
+      'SELECT user_id FROM category_users WHERE category_id = ?',
+      [categoryId],
+    );
+    return rows.map((row) => row.user_id);
+  }
+
   async addUser(orgId: number, id: number, userId: number) {
     const category = await this.findOneOrFail(orgId, id);
 

--- a/src/category/dtos/add-user.dto.ts
+++ b/src/category/dtos/add-user.dto.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+import { createZodDto } from '@anatine/zod-nestjs';
+
+export const AddUserSchema = z.object({
+  id: z.number().int(),
+});
+
+export class AddUserDto extends createZodDto(AddUserSchema) {}

--- a/src/category/entities/category.entity.ts
+++ b/src/category/entities/category.entity.ts
@@ -1,8 +1,11 @@
+import { User } from '@/user';
 import { Exclude, Expose } from 'class-transformer';
 import {
   Column,
   Entity,
   JoinColumn,
+  JoinTable,
+  ManyToMany,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -43,6 +46,14 @@ export class Category {
 
   @Column()
   position?: number;
+
+  @ManyToMany(() => User, (user) => user.categories)
+  @JoinTable({
+    name: 'category_users',
+    joinColumn: { name: 'category_id' },
+    inverseJoinColumn: { name: 'user_id' },
+  })
+  users?: User[];
 
   @Column({ name: 'created_at' })
   @Expose()

--- a/src/common/guards/agent.guard.ts
+++ b/src/common/guards/agent.guard.ts
@@ -1,0 +1,14 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Request } from 'express';
+import { User } from '@/user';
+
+@Injectable()
+export class AgentGuard implements CanActivate {
+  canActivate(ctx: ExecutionContext): boolean {
+    const user = ctx.switchToHttp().getRequest<Request>().user as User;
+    if (!user) {
+      throw new Error('No user in request, check guards configuration');
+    }
+    return user.isAgent();
+  }
+}

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -1,2 +1,3 @@
+export { AgentGuard } from './agent.guard';
 export { AuthGuard } from './auth.guard';
 export { MasterKeyGuard } from './master-key.guard';

--- a/src/database/migrations/1650513918783-create-category_users-table.ts
+++ b/src/database/migrations/1650513918783-create-category_users-table.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class createCategoryUsersTable1650513918783
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE category_users (
+        category_id int(11) unsigned NOT NULL,
+        user_id     int(11) unsigned NOT NULL,
+        PRIMARY KEY (category_id,user_id),
+        INDEX ix_category_users_user_id (user_id)
+      ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP TABLE category_users;');
+  }
+}

--- a/src/ticket/ticket.service.ts
+++ b/src/ticket/ticket.service.ts
@@ -97,12 +97,15 @@ export class TicketService {
     await this.categoryService.findOneOrFail(orgId, data.categoryId);
     await this.userService.findOneOrFail(orgId, data.requesterId);
 
+    const assigneeIds = await this.categoryService.getUserIds(data.categoryId);
+
     const ticket = new Ticket();
     ticket.orgId = orgId;
     ticket.seq = await this.getNextSequence(orgId);
     ticket.status = status.new;
     ticket.requesterId = data.requesterId;
     ticket.categoryId = data.categoryId;
+    ticket.assigneeId = _.sample(assigneeIds);
     ticket.title = data.title;
     ticket.content = data.content;
     ticket.htmlContent = this.markdownService.render(data.content);

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,6 +1,7 @@
 import { Exclude, Expose } from 'class-transformer';
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, Entity, ManyToMany, PrimaryGeneratedColumn } from 'typeorm';
 import argon2 from 'argon2';
+import { Category } from '@/category/entities/category.entity';
 import { UserRole } from '../types';
 
 @Entity('user')
@@ -26,6 +27,9 @@ export class User {
 
   @Column()
   role: UserRole;
+
+  @ManyToMany(() => Category, (category) => category.users)
+  categories?: Category[];
 
   @Column({ name: 'created_at' })
   @Expose()


### PR DESCRIPTION
如题。合完再做前端 👀 

之前是直接把客服负责的分类以数组的形式存到 _User 表里了，categories 很自然的就是 user 的属性。
新的实现使用中间表存储用户 - 分类的关系。目前看不出是应该在 users 的返回结果中填充 categories，还是在 categories 的结果中填充 users。索性就都不填充，用最标准的方式获取和管理负责分类的用户：
- `GET /categories/:id/users`
- `POST /categories/:id/users`
- `DELETE /categories/:id/users/:userId`

等相应的使用场景出来后再考虑填充进来。